### PR TITLE
230 rename query variables with camel case

### DIFF
--- a/packages/web/src/layout/navigation/upload/Upload.tsx
+++ b/packages/web/src/layout/navigation/upload/Upload.tsx
@@ -44,7 +44,7 @@ import DataInputs from './DataInputs';
 
 import {UploadMutation} from '../../../__generated__/UploadMutation.graphql';
 
-const UploadMutation = graphql`
+export const uploadMutation = graphql`
   mutation UploadMutation(
     $title: String!
     $description: String
@@ -88,7 +88,7 @@ function Upload() {
   const {isOpen, onOpen, onClose} = useDisclosure();
 
   const [commitMutation, isMutationInFlight] =
-    useMutation<UploadMutation>(UploadMutation);
+    useMutation<UploadMutation>(uploadMutation);
 
   const formik = useFormik<UploadForm>({
     validationSchema: uploadPostSchema,

--- a/packages/web/src/post/Post.tsx
+++ b/packages/web/src/post/Post.tsx
@@ -95,7 +95,7 @@ const PostUpdateMutation = graphql`
   }
 `;
 
-const PostDeleteMutation = graphql`
+export const postDeleteMutation = graphql`
   mutation PostDeleteMutation($input: DeletePostInput!) {
     deletePost(input: $input) {
       clientMutationId
@@ -121,7 +121,7 @@ function Post(props: PostProps) {
   const [updatePost, isUpdating] =
     useMutation<PostUpdateMutation>(PostUpdateMutation);
   const [deletePost, isDeleting] =
-    useMutation<PostDeleteMutation>(PostDeleteMutation);
+    useMutation<PostDeleteMutation>(postDeleteMutation);
   const {post} = usePreloadedQuery<PostQuery>(postQuery, initialQueryRef);
 
   const formik = useFormik({

--- a/packages/web/src/post/Post.tsx
+++ b/packages/web/src/post/Post.tsx
@@ -76,7 +76,7 @@ export const postQuery = graphql`
   }
 `;
 
-const PostUpdateMutation = graphql`
+export const postUpdateMutation = graphql`
   mutation PostUpdateMutation($input: UpdatePostInput!) {
     updatePost(input: $input) {
       post {
@@ -119,7 +119,7 @@ function Post(props: PostProps) {
   const [playing, setPlaying] = useState(false);
 
   const [updatePost, isUpdating] =
-    useMutation<PostUpdateMutation>(PostUpdateMutation);
+    useMutation<PostUpdateMutation>(postUpdateMutation);
   const [deletePost, isDeleting] =
     useMutation<PostDeleteMutation>(postDeleteMutation);
   const {post} = usePreloadedQuery<PostQuery>(postQuery, initialQueryRef);

--- a/packages/web/src/post/PostAddComment.tsx
+++ b/packages/web/src/post/PostAddComment.tsx
@@ -25,7 +25,7 @@ import {Button, chakra, Input} from '@chakra-ui/react';
 
 import {PostAddCommentMutation} from '../__generated__/PostAddCommentMutation.graphql';
 
-const PostAddCommentMutation = graphql`
+export const postAddCommentMutation = graphql`
   mutation PostAddCommentMutation($input: CommentPostInput!) {
     commentPost(input: $input) {
       post {
@@ -53,7 +53,7 @@ function PostAddComment(props: PostAddCommentProps) {
   const {postId} = props;
 
   const [comment, isCommenting] = useMutation<PostAddCommentMutation>(
-    PostAddCommentMutation,
+    postAddCommentMutation,
   );
 
   const formik = useFormik({

--- a/packages/web/src/profile/Profile.tsx
+++ b/packages/web/src/profile/Profile.tsx
@@ -57,7 +57,7 @@ export const profileQuery = graphql`
   }
 `;
 
-const ProfileUpdateMutation = graphql`
+export const profileUpdateMutation = graphql`
   mutation ProfileUpdateMutation($input: UpdateProfileInput!) {
     updateProfile(input: $input) {
       profile {
@@ -83,7 +83,7 @@ function Profile(props: ProfileProps) {
   const [editing, setEditing] = useState(false);
 
   const [commitMutation, isFlying] = useMutation<ProfileUpdateMutation>(
-    ProfileUpdateMutation,
+    profileUpdateMutation,
   );
 
   const {profile} = usePreloadedQuery<ProfileQuery>(

--- a/packages/web/src/profile/ProfileVideos.tsx
+++ b/packages/web/src/profile/ProfileVideos.tsx
@@ -31,7 +31,7 @@ import {ProfileVideosQuery} from '../__generated__/ProfileVideosQuery.graphql';
 
 import ProfilePost from './ProfilePost';
 
-const ProfileVideosQuery = graphql`
+export const profileVideosQuery = graphql`
   query ProfileVideosQuery($username: String!, $first: Int!, $after: String) {
     profile(username: $username) {
       id
@@ -68,7 +68,7 @@ type CurrentPostsProps = {
 function CurrentPosts(props: CurrentPostsProps) {
   const {preloadedQuery, setAfterPost} = props;
 
-  const query = usePreloadedQuery(ProfileVideosQuery, preloadedQuery);
+  const query = usePreloadedQuery(profileVideosQuery, preloadedQuery);
   const posts = query.profile.posts;
 
   return (
@@ -106,7 +106,7 @@ function ProfileVideos(props: ProfileVideoProps) {
   const [afterPost, setAfterPost] = useState<string>();
 
   const [preloadedQuery, loadQuery] =
-    useQueryLoader<ProfileVideosQuery>(ProfileVideosQuery);
+    useQueryLoader<ProfileVideosQuery>(profileVideosQuery);
 
   useEffect(() => {
     loadQuery({

--- a/packages/web/src/timeline/TimelinePost.tsx
+++ b/packages/web/src/timeline/TimelinePost.tsx
@@ -36,7 +36,7 @@ import {
 import {TimelineQuery$data} from '../__generated__/TimelineQuery.graphql';
 import {TimelinePostLikeMutation} from '../__generated__/TimelinePostLikeMutation.graphql';
 
-const TimelinePostLikeMutation = graphql`
+export const timelinePostLikeMutation = graphql`
   mutation TimelinePostLikeMutation($input: LikePostInput!) {
     likePost(input: $input) {
       post {
@@ -72,7 +72,7 @@ function TimelinePost(props: PostProps) {
   const [playing, setPlaying] = useState(selected);
 
   const [like, isLiking] = useMutation<TimelinePostLikeMutation>(
-    TimelinePostLikeMutation,
+    timelinePostLikeMutation,
   );
 
   useEffect(() => {

--- a/packages/web/src/timeline/TimelinePost.tsx
+++ b/packages/web/src/timeline/TimelinePost.tsx
@@ -57,12 +57,12 @@ export const timelinePostLikeMutation = graphql`
   }
 `;
 
-type PostProps = {
+type TimelinePostProps = {
   readonly selected?: boolean;
   readonly data: TimelineQuery$data['forYou']['edges'][0]['node'];
 };
 
-function TimelinePost(props: PostProps) {
+function TimelinePost(props: TimelinePostProps) {
   const {selected = false, data} = props;
 
   const videoRef = useRef<HTMLVideoElement>();


### PR DESCRIPTION
- refactor(web): make camel case `timelinePostLikeMutation`
- refactor(web): rename `PostProps` to `TimelinePostProps`
- refactor(web): make camel case `postDeleteMutation`
- refactor(web): make camel case `postUpdateMutation`
- refactor(web): make camel case `postAddCommentMutation`
- refactor(web): make camel case `uploadMutation`
- refactor(web): make camel case `profileVideosQuery`
- refactor(web): make camel case `profileUpdateMutation`
